### PR TITLE
cache ens names using cachetools

### DIFF
--- a/plugins/rocketpool.py
+++ b/plugins/rocketpool.py
@@ -87,6 +87,9 @@ class RocketPool(commands.Cog):
     contract = self.get_contract("rocketMinipoolManager")
     return contract.functions.getMinipoolExists(address).call()
 
+  def get_ens_name(self, address):
+    return self.ens.name(address)
+
   def get_proposal_info(self, event):
     contract = self.address_to_contract[event['address']]
     result = {
@@ -181,7 +184,7 @@ class RocketPool(commands.Cog):
       if str(arg_value).startswith("0x"):
         name = ""
         if self.w3.isAddress(arg_value):
-          name = self.ens.name(arg_value)
+          name = self.get_ens_name(arg_value)
         if not name:
           # fallback when no ens name is found or when the hex isn't an address to begin with
           name = f"{short_hex(arg_value)}"

--- a/plugins/rocketpool.py
+++ b/plugins/rocketpool.py
@@ -5,6 +5,7 @@ import warnings
 
 import discord
 import termplotlib as tpl
+from cachetools.func import ttl_cache
 from discord import Embed
 from discord.ext import commands, tasks
 from ens import ENS
@@ -69,7 +70,7 @@ class RocketPool(commands.Cog):
       self.run_loop.start()
 
   def get_address_from_storage_contract(self, name):
-    log.debug(f"retrieving address for {name}")
+    log.debug(f"retrieving address for {name} Contract")
     sha3 = Web3.soliditySha3(["string", "string"], ["contract.address", name])
     return self.storage_contract.functions.getAddress(sha3).call()
 
@@ -87,7 +88,9 @@ class RocketPool(commands.Cog):
     contract = self.get_contract("rocketMinipoolManager")
     return contract.functions.getMinipoolExists(address).call()
 
+  @ttl_cache(ttl=360)
   def get_ens_name(self, address):
+    log.debug(f"retrieving ens name for {address}")
     return self.ens.name(address)
 
   def get_proposal_info(self, event):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ humanize~=3.11.0
 discord.py~=1.7.3
 python-dotenv~=0.19.0
 termplotlib~=0.3.8
+cachetools~=4.2.2


### PR DESCRIPTION
- Revert "use ens lib directly"
- cache ens names using ttl cache from cachetools
